### PR TITLE
fix the problem of large sparse matrix of Seurat

### DIFF
--- a/R/findmarkergenes.R
+++ b/R/findmarkergenes.R
@@ -182,7 +182,7 @@
 findmarkergenes <- function(object, species = NULL, cluster = "All", match_CellMatch = FALSE, cancer = NULL, 
     tissue = NULL, cell_min_pct = 0.25, logfc = 0.25, pvalue = 0.05) {
     # extract normalized data from Seurat object
-    ndata <- as.data.frame(object[["RNA"]]@data)
+    ndata <- object[["RNA"]]@data
     # extract cluster information of all single cells
     clu_info <- Seurat::Idents(object = object)
     clu_info <- data.frame(cell = names(clu_info), cluster = as.character(clu_info), stringsAsFactors = F)

--- a/R/findmarkergenes.R
+++ b/R/findmarkergenes.R
@@ -177,7 +177,7 @@
 #' @details Supratentorial Primitive Neuroectodermal Tumor: Brain.
 #' @seealso \url{https://github.com/ZJUFanLab/scCATCH}
 #' @import Seurat stats
-#' @import Matrix rowMeans
+#' @importFrom Matrix rowMeans
 #' @export findmarkergenes
 
 findmarkergenes <- function(object, species = NULL, cluster = "All", match_CellMatch = FALSE, cancer = NULL, 

--- a/R/findmarkergenes.R
+++ b/R/findmarkergenes.R
@@ -177,6 +177,7 @@
 #' @details Supratentorial Primitive Neuroectodermal Tumor: Brain.
 #' @seealso \url{https://github.com/ZJUFanLab/scCATCH}
 #' @import Seurat stats
+#' @import Matrix rowMeans
 #' @export findmarkergenes
 
 findmarkergenes <- function(object, species = NULL, cluster = "All", match_CellMatch = FALSE, cancer = NULL, 
@@ -226,7 +227,7 @@ findmarkergenes <- function(object, species = NULL, cluster = "All", match_CellM
     genedata1 <- as.data.frame(table(genedata$new_name), stringsAsFactors = F)
     genedata1 <- genedata1[genedata1$Freq == 1, ]
     genedata <- genedata[genedata$new_name %in% genedata1$Var1, ]
-    ndata <- ndata[genedata$raw_name, ]
+    ndata <- ndata[genedata$raw_name, , drop=FALSE ]
     rownames(ndata) <- genedata$new_name
     cat('\n')
     cat("Note: the new data matrix includes", ncol(ndata), "cells and", nrow(ndata), "genes.", "\n")

--- a/R/findmarkergenes.R
+++ b/R/findmarkergenes.R
@@ -177,7 +177,6 @@
 #' @details Supratentorial Primitive Neuroectodermal Tumor: Brain.
 #' @seealso \url{https://github.com/ZJUFanLab/scCATCH}
 #' @import Seurat stats
-#' @importFrom Matrix rowMeans
 #' @export findmarkergenes
 
 findmarkergenes <- function(object, species = NULL, cluster = "All", match_CellMatch = FALSE, cancer = NULL, 
@@ -371,7 +370,7 @@ findmarkergenes <- function(object, species = NULL, cluster = "All", match_CellM
             # assigning clusters and avg_logfc
             clu_marker2$cluster <- clu_pair1$cluster1[j]
             clu_marker2$comp_cluster <- clu_pair1$cluster2[j]
-            clu_marker2$avg_logfc <- rowMeans(ndata1) - rowMeans(ndata2)
+            clu_marker2$avg_logfc <- Matrix::rowMeans(ndata1) - Matrix::rowMeans(ndata2)
             # assigning pct and pvalue
             for (k in 1:nrow(clu_marker2)) {
                 genedata1 <- as.numeric(ndata1[k, ])


### PR DESCRIPTION

If the Seurat use the very large sparse matrix to store gene expression matrix,  the `as.data.frame` will not work. So, I remove the `as.data.frame` and use Matrix::rowMeans to calculate the means of sparse matrix. Becuase, the rowMeans will still convert the data.frame to matrix, it is not neccessary to convert the orgin matrix to data.frame.

>原来代码中用了as.data.frame去转换Seurat的表达量矩阵，而R语言是无法直接处理非常大的稀疏矩阵，参考[R语言的稀疏矩阵学习记录](http://xuzhougeng.top/archives/R-Sparse-Matrix-Note)，而且后续使用的 rowMeans去计算均值时，R语言会把data.frame转成matrix再计算，因此，源代码中的as.data.frame可以删除. 并且不会影响最终运行结果